### PR TITLE
fix bug which triggered system dependency updates only when go_autoinstall option was enabled

### DIFF
--- a/tasks/common/preflight.yml
+++ b/tasks/common/preflight.yml
@@ -61,11 +61,10 @@
 
 - name: Update system dependencies
   become: true
-  when: go_autoinstall and ansible_distribution|lower != "ubuntu"
+  when: ansible_distribution|lower != "ubuntu"
   package:
-    name: "{{ item }}"
+    name: "{{ system_dependencies }}"
     state: present
-  loop: "{{ system_dependencies }}"
   tags:
     - preflight
 


### PR DESCRIPTION
System dependency updates are always necessary for proper runtime.