### PR TITLE
[binary rename + readme examples]

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ custom_miner_properties:
   Environment: "LOTUS_STORAGE_PATH=/var/data/lotus-storage-miner"
 ```
 
+To set multiple environment variables, they need to be space-separated:
+```yaml
+custom_unit_properties:
+  Environment: "BELLMAN_CPU_UTILIZATION=0.875 FIL_PROOFS_MAXIMIZE_CACHING=1 FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1"
+custom_miner_properties:
+  Environment: "BELLMAN_CPU_UTILIZATION=0.875 FIL_PROOFS_MAXIMIZE_CACHING=1 FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1"
+```
+
 Reference the [systemd.service](http://man7.org/linux/man-pages/man5/systemd.service.5.html) *man* page for a configuration overview and reference.
 
 #### Uninstall
@@ -222,6 +230,7 @@ launch `lotus` service and `lotus-storage-miner` agents with custom runtime/stor
       install_type: source
       lotus_path: /mnt/lotus
       lotus_storage_path: /mnt/lotus/miner
+      managed_services: ['lotus', 'lotus-storage-miner']
       config:
         Metrics:
           Nickname: "my_miner"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Variables are available and organized according to the following software & mach
 - dedicated service user and group used by `lotus` for privilege separation (see [here](https://www.beyondtrust.com/blog/entry/how-separation-privilege-improves-security) for details)
 
 `install_type: <archive | source>` (**default**: archive)
-- **archive**: currently supported by Ubuntu and Fedora distributions (due to availibity of version >= 2.27 of the `glibc` *GNU libc libraries* package -- see [here](http://fr2.rpmfind.net/linux/rpm2html/search.php?query=glibc&submit=Search+...&system=&arch=) for per-distribution package availability) and compatible with both **tar and zip** formats, installation of Lotus via compressed archives results in the direct download of its component binaries, the `lotus` network client and `lotus-storage-miner` mining software, from the specified archive url.
+- **archive**: currently supported by Ubuntu and Fedora distributions (due to availibity of version >= 2.27 of the `glibc` *GNU libc libraries* package -- see [here](http://fr2.rpmfind.net/linux/rpm2html/search.php?query=glibc&submit=Search+...&system=&arch=) for per-distribution package availability) and compatible with both **tar and zip** formats, installation of Lotus via compressed archives results in the direct download of its component binaries, the `lotus` network client and `lotus-miner` mining software, from the specified archive url.
 
   **note:** archived installation binaries can be obtained from the official [releases](https://github.com/filecoin-project/lotus/releases) site or those generated from development/custom sources.
 
@@ -81,7 +81,7 @@ Variables are available and organized according to the following software & mach
 - path on target host the `lotus` service should establish as its runtime configuration and data directory.
 
 `lotus_storage_path: </path/to/miner/data-dir>` (**default**: `/opt/lotus/.lotusstorage`)
-- path on target host the `lotus-storage-miner` service should establish as its runtime and data storage directory.
+- path on target host the `lotus-miner` service should establish as its runtime and data storage directory.
 
 `go_autoinstall: <true|false>` (**default**: `false`)
 - automatically install the specified version of Go packages and binaries. Useful when installing from source which requires `go` as a part of its build process
@@ -125,8 +125,8 @@ _The following variables can be customized to manage the content of this TOML co
 `extra_run_args: <lotus-cli-options>` (**default**: `[]`)
 - list of `lotus daemon` commandline arguments to pass to the binary at runtime for customizing launch. Supporting full expression of `lotus daemon`'s [cli](https://gist.github.com/0x0I/53533099efcee8c87a49301e79358a0a), this variable enables the launch to be customized according to the user's specification.
 
-`extra_miner_args: <lotus-storage-miner-cli-options>` (**default**: `[]`)
-- list of `lotus-storage-miner run` commandline arguments to pass to the binary at runtime for customizing launch. Supporting full expression of `lotus-storage-miner run`'s [cli](https://gist.github.com/0x0I/71b7a7c25a7f558d4fd9f0ff39a896d6), this variable enables the launch to be customized according to the user's specification.
+`extra_miner_args: <lotus-miner-cli-options>` (**default**: `[]`)
+- list of `lotus-miner run` commandline arguments to pass to the binary at runtime for customizing launch. Supporting full expression of `lotus-miner run`'s [cli](https://gist.github.com/0x0I/71b7a7c25a7f558d4fd9f0ff39a896d6), this variable enables the launch to be customized according to the user's specification.
 
 `custom_unit_properties: <hash-of-systemd-service-settings>` (**default**: `[]`)
 - hash of settings used to customize the `[Service]` unit configuration and execution environment of the *Lotus* **systemd** service.
@@ -140,7 +140,7 @@ _The following variables can be customized to manage the content of this TOML co
 custom_unit_properties:
   Environment: "LOTUS_PATH=/var/data/lotus"
 custom_miner_properties:
-  Environment: "LOTUS_STORAGE_PATH=/var/data/lotus-storage-miner"
+  Environment: "LOTUS_STORAGE_PATH=/var/data/lotus-miner"
 ```
 
 To set multiple environment variables, they need to be space-separated:
@@ -221,7 +221,7 @@ expose `lotus` API/JSON-RPC server on non-loopback (wildcard/*) address
           ListenAddresses: ["/ip4/0.0.0.0/tcp/0", "/ip6/::/tcp/0"]
 ```
 
-launch `lotus` service and `lotus-storage-miner` agents with custom runtime/storage paths and launch options:
+launch `lotus` service and `lotus-miner` agents with custom runtime/storage paths and launch options:
 ```
 - hosts: all
   roles:
@@ -230,7 +230,7 @@ launch `lotus` service and `lotus-storage-miner` agents with custom runtime/stor
       install_type: source
       lotus_path: /mnt/lotus
       lotus_storage_path: /mnt/lotus/miner
-      managed_services: ['lotus', 'lotus-storage-miner']
+      managed_services: ['lotus', 'lotus-miner']
       config:
         Metrics:
           Nickname: "my_miner"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -26,7 +26,7 @@
 - name: Stop lotus storage miner systemd service
   become: true
   service:
-    name: lotus-storage-miner
+    name: lotus-miner
     state: stopped
     enabled: false
   listen: Uninstall service
@@ -35,7 +35,7 @@
 - name: Remove Lotus storage miner systemd service file
   become: true
   file:
-    path: "/etc/systemd/system/lotus-storage-miner.service"
+    path: "/etc/systemd/system/lotus-miner.service"
     state: absent
   listen: Uninstall service
 

--- a/tasks/common/launch/lotus-miner_launch.yml
+++ b/tasks/common/launch/lotus-miner_launch.yml
@@ -4,7 +4,7 @@
     name: 0x0i.systemd
   vars:
     unit_config:
-      - name: lotus-storage-miner
+      - name: lotus-miner
         Unit:
           Description: Lotus Storage Miner
           Documentation: https://github.com/filecoin-project/lotus/blob/master/documentation/en/mining.md
@@ -20,7 +20,7 @@
 - name: Ensure start of lotus miner service
   become: true
   service:
-    name: lotus-storage-miner
+    name: lotus-miner
     state: started
     enabled: "yes"
   changed_when: false

--- a/tasks/common/preflight.yml
+++ b/tasks/common/preflight.yml
@@ -70,7 +70,7 @@
 - name: Set lotus miner unit [Service] configuration
   set_fact:
     _default_miner_unit:
-      ExecStart: "/usr/local/bin/lotus-storage-miner run {{ extra_miner_args|join(' ') }}"
+      ExecStart: "/usr/local/bin/lotus-miner run {{ extra_miner_args|join(' ') }}"
       User: "{{ lotus_user }}"
       Group: "{{ lotus_user }}"
       StandardOutput: journal

--- a/test/integration/launch/launch_miner/default_playbook.yml
+++ b/test/integration/launch/launch_miner/default_playbook.yml
@@ -5,6 +5,6 @@
     - ansible-role-lotus
   vars:
     version: v0.1.5
-    managed_services: ['lotus', 'lotus-storage-miner']
+    managed_services: ['lotus', 'lotus-miner']
     extra_run_args:
       - '--bootstrap'

--- a/test/integration/launch/launch_miner/default_test.rb
+++ b/test/integration/launch/launch_miner/default_test.rb
@@ -1,13 +1,13 @@
 title "Lotus storage miner launch test suite"
 
-describe file('/etc/systemd/system/lotus-storage-miner.service') do
+describe file('/etc/systemd/system/lotus-miner.service') do
   it { should exist }
   its('owner') { should eq 'root' }
   its('group') { should eq 'root' }
   its('mode') { should cmp '0644' }
 end
 
-describe service('lotus-storage-miner') do
+describe service('lotus-miner') do
   it { should be_installed }
   it { should be_enabled }
   it { should be_running }


### PR DESCRIPTION
* Renames `lotus-storage-miner` to `lotus-miner` in all locations.
* Adds an example for `managed_services` as by default it will not include the configuration.
* Adds an example for Env Vars.