### PR TITLE
specify cargo path as a cargo_home variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,12 @@ install `lotus` for the `calibration` network; include SHA extensions; include r
 
 - hosts: all
   environment:
-    # Path for rust/cargo
-    PATH: "/home/{{ ansible_env.HOME }}/.cargo/bin:{{ ansible_env.PATH }}"
     # SHA Extensions
     RUSTFLAGS: "-C target-cpu=native -g"
     FFI_BUILD_FROM_SOURCE: 1
+  vars:
+    # Path for rust/cargo
+    cargo_home: "{{ /home/{{ ansible_env.HOME }}/.cargo }}"
   roles:
     - role: 0x0I.lotus
       vars:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ custom_unit_properties: {}
 custom_miner_properties: {}
 
 managed_services: ['lotus']
+
+cargo_home: "{{ /home/{{ ansible_env.HOME }}/.cargo }}"

--- a/tasks/common/install.yml
+++ b/tasks/common/install.yml
@@ -42,7 +42,7 @@
     chdir: "{{ install_dir }}"
     target: lotus-bench
   environment:
-    PATH: /usr/local/bin:{{ ansible_env.PATH }}
+    PATH: "{{ cargo_home }}/bin:{{ ansible_env.PATH }}"
   changed_when: false
   tags:
     - install

--- a/tasks/common/install/source_install.yml
+++ b/tasks/common/install/source_install.yml
@@ -17,7 +17,7 @@
     chdir: "{{ install_dir }}"
     target: clean
   environment:
-    PATH: /usr/local/bin:{{ ansible_env.PATH }}
+    PATH: "{{ cargo_home }}/bin:{{ ansible_env.PATH }}"
   changed_when: false
   tags:
     - install
@@ -30,7 +30,7 @@
     chdir: "{{ install_dir }}"
     target: all
   environment:
-    PATH: /usr/local/bin:{{ ansible_env.PATH }}
+    PATH: "{{ cargo_home }}/bin:{{ ansible_env.PATH }}"
   changed_when: false
   tags:
     - install
@@ -43,7 +43,7 @@
     chdir: "{{ install_dir }}"
     target: install
   environment:
-    PATH: /usr/local/bin:{{ ansible_env.PATH }}
+    PATH: "{{ cargo_home }}/bin:{{ ansible_env.PATH }}"
   changed_when: false
   tags:
     - install


### PR DESCRIPTION
I've run into an issue with a setup that has rust/cargo in `/opt/rust/.cargo`. 

These instructions from the README, didn't work for .cargo outside of $HOME
```yml
- hosts: all
  environment:
    # Path for rust/cargo
    PATH: "/home/{{ ansible_env.HOME }}/.cargo/bin:{{ ansible_env.PATH }}"
```

Because the `tasks/common/install/source_install.yml` would always override the PATH in the above snippet.
```yml
# tasks/common/install/source_install.yml
...
environment:
    PATH: /usr/local/bin:{{ ansible_env.PATH }}
...
```

This way the target path can be specified via the `cargo_home: "/opt/rust/.cargo"` variable
 
